### PR TITLE
Fix missing EmailJS config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,4 +87,5 @@ coverage/
 
 # Flask / Werkzeug
 instance/*
-!instance/.keep 
+!instance/.keep
+!frontend/src/app/lib/

--- a/frontend/src/app/lib/config.ts
+++ b/frontend/src/app/lib/config.ts
@@ -1,0 +1,5 @@
+export const emailJSConfig = {
+  serviceId: process.env.NEXT_PUBLIC_EMAILJS_SERVICE_ID ?? '',
+  templateId: process.env.NEXT_PUBLIC_EMAILJS_TEMPLATE_ID ?? '',
+  publicKey: process.env.NEXT_PUBLIC_EMAILJS_PUBLIC_KEY ?? '',
+};


### PR DESCRIPTION
## Summary
- add config for EmailJS and load from env vars
- allow new lib directory in `.gitignore`

## Testing
- `python -m py_compile backend/src/main.py`
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68464cde32208326a2ae8e5e4226a087